### PR TITLE
fix: status badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Netlify Status](https://api.netlify.com/api/v1/badges/79deda3b-d696-4878-b15d-d9f3a862bdfc/deploy-status)](https://app.netlify.com/sites/awesome-swanson-e132b6/deploys)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/79deda3b-d696-4878-b15d-d9f3a862bdfc/deploy-status)](https://app.netlify.com/sites/build-plugin-template/deploys)
 
 Template repository to create new Netlify Build plugins.
 


### PR DESCRIPTION
I renamed the site on Netlify which inadvertently broke the status badge link