### PR TITLE
test: disable telemetry in test

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -15,6 +15,7 @@ test('Netlify Build should not fail', async (t) => {
   const { success, logs } = await netlifyBuild({
     config: NETLIFY_CONFIG,
     buffer: true,
+    telemetry: false
   })
 
   // Netlify Build output


### PR DESCRIPTION
Running the tests locally is quite flaky without it