### PR TITLE
fix: fix `files` in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,8 @@
   "description": "Netlify Build plugin - {{description}}",
   "main": "src/index.js",
   "files": [
-    "src",
-    "manifest.yml",
-    "!*~"
+    "src/**/*.js",
+    "manifest.yml"
   ],
   "scripts": {
     "init": "npm install --loglevel error --no-audit --no-fund && node init/bin.js",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "main": "src/index.js",
   "files": [
     "src/**/*.js",
+    "src/**/*.json",
+    "src/**/*.sh",
+    "src/**/*.html",
+    "src/**/*.ejs",
     "manifest.yml"
   ],
   "scripts": {


### PR DESCRIPTION
npm 7 changed the way globbing patterns are interpreted in `files` in `package.json`. This is undocumented, so I'm not sure whether this is a bug or not. This results in all `*~` files (Vim temporary files) to be published to npm, which can double the package size. 

This PR fixes this. I ran `npm pack --dry` before and after to ensure no files were being omitted.