### PR TITLE
chore: ignore `strip-ansi` updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -2,6 +2,17 @@
   extends: ['github>netlify/renovate-config:default'],
   ignorePresets: [':prHourlyLimit2'],
   semanticCommits: true,
-  masterIssue: true,
-  automerge: false,
+  dependencyDashboard: true,
+  automerge: true,
+  packageRules: [
+    {
+      packageNames: [
+        // Those cannot be upgraded to requiring ES modules
+        'strip-ansi',
+      ],
+      major: {
+        enabled: false,
+      },
+    },
+  ],
 }


### PR DESCRIPTION
`strip-ansi` requires using ES modules.